### PR TITLE
Rename user management hooks to use storage management

### DIFF
--- a/src/components/common/Error.tsx
+++ b/src/components/common/Error.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Typography } from '.'
+import { COLORS } from '@/styles'
+
+export const Error = {
+  textError: React.memo((props) => (
+    <Typography.h3 style={{ color: COLORS.ERROR }} {...props}>
+      글자수 20을 초과할 수 없습니다.
+    </Typography.h3>
+  )),
+  textareaError: React.memo((props) => (
+    <Typography.h3 style={{ color: COLORS.ERROR }} {...props}>
+      글자수 50을 초과할 수 없습니다.
+    </Typography.h3>
+  ))
+}

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { styled } from 'styled-components'
+import { COLORS } from '@/styles'
+
+const HeaderContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid ${COLORS.GRAY_300};
+  padding: 8px 14px;
+`
+
+interface Props {
+  children: React.ReactNode
+}
+
+export function Header({ children }: Props) {
+  return <HeaderContainer>{children}</HeaderContainer>
+}

--- a/src/components/common/Title.tsx
+++ b/src/components/common/Title.tsx
@@ -1,0 +1,27 @@
+import React, { HTMLAttributes, PropsWithChildren } from 'react'
+import styled from 'styled-components'
+import { typography } from '@/styles'
+
+const H1 = styled.h1`
+  ${typography.h1}
+`
+const H2 = styled.h2`
+  ${typography.h2}
+`
+const H3 = styled.h3`
+  ${typography.h3}
+`
+
+/**
+ * Head tag 표준 HTML 속성과 children 명시
+ */
+type HeadingProps = PropsWithChildren<HTMLAttributes<HTMLHeadingElement>>
+
+/**
+ * Typography가 일정하게 쓰이는 것 같아 Design system과 연관해서 export
+ */
+export const Typography = {
+  h1: React.memo<HeadingProps>((props) => <H1 {...props} />),
+  h2: React.memo<HeadingProps>((props) => <H2 {...props} />),
+  h3: React.memo<HeadingProps>((props) => <H3 {...props} />)
+}

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,0 +1,3 @@
+export * from './Error'
+export * from './Title'
+export * from './Header'

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,1 @@
-export * from './useUserManagement'
+export * from './useStorageManagement'

--- a/src/hooks/useStorageManagement.ts
+++ b/src/hooks/useStorageManagement.ts
@@ -1,18 +1,24 @@
 import { v4 } from 'uuid'
 import { useRef, useState } from 'react'
-import { createLocalStorage, getStorageType } from '@/utils'
-import { StorageInterface, User } from '@/types'
+import { createLocalStorage, formatDate, getStorageType } from '@/utils'
+import { PreprocessedUser, StorageInterface, User } from '@/types'
 import { mockUsers } from '@/configs'
 
-export function useUserManagement() {
+/**
+ * getStorageType 함수 리턴값에 따른 local-storage 이용 여부 결정
+ * in-memory 이용시 편의성 mockUsers 반환.
+ * Storage에 CRUD 기능이 있기에 좀 더 명확하게 Management라는 네이밍 추가
+ */
+export function useStorageManagement() {
   const storageRef = useRef<StorageInterface | null>(getStorageType() === 'local-storage' ? createLocalStorage() : null)
   const [users, setUsers] = useState<User[]>(() => {
     return storageRef.current ? storageRef.current.getAll() : [...mockUsers]
   })
 
-  const addUser = (userData: Omit<User, 'id'>) => {
+  const handleAdd = (userData: PreprocessedUser) => {
     const newUser: User = {
       id: v4(),
+      updatedAt: formatDate(new Date()),
       ...userData
     }
 
@@ -25,7 +31,7 @@ export function useUserManagement() {
     return newUser
   }
 
-  const updateUser = (updated: User) => {
+  const handleUpdate = (updated: User) => {
     setUsers((prev) => {
       return prev.map((user) => {
         if (user.id === updated.id) {
@@ -43,7 +49,7 @@ export function useUserManagement() {
     })
   }
 
-  const deleteUser = (id: string) => {
+  const handleDelete = (id: string) => {
     setUsers((prev) => prev.filter((user) => user.id !== id))
 
     if (storageRef.current) {
@@ -53,8 +59,8 @@ export function useUserManagement() {
 
   return {
     users,
-    addUser,
-    updateUser,
-    deleteUser
+    handleAdd,
+    handleUpdate,
+    handleDelete
   }
 }

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,1 +1,2 @@
 export * from './colors'
+export * from './typography'

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -1,0 +1,22 @@
+import { css } from 'styled-components'
+import { RuleSet } from 'styled-components/dist/types'
+
+export const typography: Record<'h1' | 'h2' | 'h3', RuleSet> = {
+  h1: css`
+    font-size: 16px;
+    line-height: 24px;
+    font-weight: 600;
+  `,
+
+  h2: css`
+    font-size: 14px;
+    line-height: 22px;
+    font-weight: 400;
+  `,
+
+  h3: css`
+    font-size: 12px;
+    line-height: 20px;
+    font-weight: 400;
+  `
+}

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,9 @@
+export function formatDate(date: Date) {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+
+  const formattedDate = `${year}-${month}-${day}`
+
+  return formattedDate
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
+export * from './formatDate'
 export * from './storage'


### PR DESCRIPTION
1. Rename user management hooks to use storage management
2. Add common components: Error, Header, Title, typography styles, format time utils